### PR TITLE
Correct view name for templates

### DIFF
--- a/.compose/templates/device.json
+++ b/.compose/templates/device.json
@@ -14,7 +14,7 @@
                     },
                     {
                         "name": "rf.pair.choice.buttons.generate.default",
-                        "view": "rf.generate",
+                        "view": "rf.program",
                         "svg": "./assets/svg/socket.svg"
                     }
                 ]

--- a/.compose/templates/doorbell.json
+++ b/.compose/templates/doorbell.json
@@ -19,7 +19,7 @@
                     },
                     {
                         "name": "rf.pair.choice.buttons.generate.default",
-                        "view": "rf.generate",
+                        "view": "rf.program",
                         "svg": "./assets/svg/doorbell_alarm.svg"
                     }
                 ]

--- a/.compose/templates/socket.json
+++ b/.compose/templates/socket.json
@@ -19,7 +19,7 @@
                     },
                     {
                         "name": "rf.pair.choice.buttons.generate.default",
-                        "view": "rf.generate",
+                        "view": "rf.program",
                         "svg": "./assets/svg/socket.svg"
                     }
                 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homey-rfdriver",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "RFDriver for Homey Apps",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
A few templates had the wrong view name; `generate` instead of `program`. As a result, clicking "generate a new signal" would lead to an empty pairing window. This pull request gives them the right names.