### PR TITLE
No update on capability changes

### DIFF
--- a/lib/Device.js
+++ b/lib/Device.js
@@ -521,7 +521,9 @@ module.exports = superclass =>
 			if (!this.isPairInstance && !data.ignoreFlowTriggers) {
 				this.triggerFlowsOnData(Object.assign({}, data));
 			}
-			this.lastFrame = data;
+			if (!data.group) {
+				this.lastFrame = data;
+			}
 		}
 
 		onCmd(cmdObj) {


### PR DESCRIPTION
f onData(data)
No update on capability changes if (data.group) 
as it breaks channel and/or unit on use of Group button 
(at least KAKU v4.x )