### PR TITLE
Kyle fixes

### DIFF
--- a/.compose/locales/de.pair.json
+++ b/.compose/locales/de.pair.json
@@ -74,9 +74,9 @@
       "blinds": "Teste Deine Jalousien."
     },
     "body": {
-      "default": "Drücke eine beliebige Taste auf Deinem Gerät oder drücke auf die Taste in dem Bild oben, um das Signal zu testen. Drücke auf „weiter“, um fortzufahren.",
-      "remote": "Drücke eine beliebige Taste auf Deiner Fernbedienung oder drücke auf die Taste in dem Bild oben, um das Signal zu testen. Drücke auf „weiter“, um fortzufahren.",
-      "wall_switch": "Drücke eine beliebige Taste auf Deinem Wandschalter oder drücke auf die Tasten in dem Bild oben, um das Signal zu testen. Drücke auf „weiter“, um fortzufahren.",
+      "default": "Drücke eine beliebige Taste auf Deinem Gerät, um das Signal zu testen. Drücke auf „weiter“, um fortzufahren.",
+      "remote": "Drücke eine beliebige Taste auf Deiner Fernbedienung, um das Signal zu testen. Drücke auf „weiter“, um fortzufahren.",
+      "wall_switch": "Drücke eine beliebige Taste auf Deinem Wandschalter, um das Signal zu testen. Drücke auf „weiter“, um fortzufahren.",
       "socket_generated": "Verwende den Schalter oben, um Deine Steckdose zu testen. Drücke auf „weiter“, um fortzufahren.",
       "socket": "Verwende Deine Fernbedienung oder den Schalter oben, um Deine Steckdose zu testen. Drücke auf „weiter“, um fortzufahren.",
       "button_generated": "Verwende die Taste oben, um Dein Gerät zu testen. Drücke auf „weiter“, um fortzufahren.",

--- a/.compose/locales/en.pair.json
+++ b/.compose/locales/en.pair.json
@@ -75,9 +75,9 @@
             "blinds": "Test your blinds"
         },
         "body": {
-            "default": "Press a random button on your device or click the button in the image above to test the signal. Press next to continue.",
-            "remote": "Press a random button on your remote or click the button in the image above to test the signal. Press next to continue.",
-            "wall_switch": "Press a random button on your wall switch or click the buttons in the image above to test the signal. Press next to continue.",
+            "default": "Press a random button on your device to test the signal. Press next to continue.",
+            "remote": "Press a random button on your remote to test the signal. Press next to continue.",
+            "wall_switch": "Press a random button on your wall switch to test the signal. Press next to continue.",
             "socket_generated": "Use the switch above to test your socket. Press next to continue.",
             "socket": "Use your remote or the switch above to test your socket. Press next to continue.",
             "button_generated": "Use the button above to test your device. Press next to continue.",
@@ -109,7 +109,7 @@
             "default": "Configure your device dipswitches"
         },
         "body": {
-            "default": "Click on the dipswitches above to put them in the same arrangement as those of your device, then click program."
+            "default": "Click on the dipswitches to put them in the same arrangement as those of your device, plug in the socket, then click program."
         }
     },
     "done": {

--- a/.compose/locales/nl.json
+++ b/.compose/locales/nl.json
@@ -90,6 +90,10 @@
         "device_exists": "Apparaat is al gekoppeld met Homey.",
         "no_device": "Er is geen apparaat ingesteld. Sluit de pairing wizard en probeer opnieuw.",
         "no_settings": "Geen instelling object. Probeer aub opnieuw.",
-        "invalid_device": "Het apparaat dat is aangemaakt is incorrect. Verwijder dit apparaat en probeer opnieuw."
+        "invalid_device": "Het apparaat dat is aangemaakt is incorrect. Verwijder dit apparaat en probeer opnieuw.",
+        "invalid_device_data": "Het apparaat dat is aangemaakt is incorrect. Verwijder dit apparaat en probeer opnieuw.",
+        "data_no_object": "Geen data object ontvangen",
+        "pairdevice_invalid_data": "Nieuw gekoppelde apparaat data is incorrect, wijzigingen worden teruggedraaid.",
+        "invalid_send_data": "Data om te versturen is incorrect."
     }
 }

--- a/.compose/locales/nl.pair.json
+++ b/.compose/locales/nl.pair.json
@@ -25,7 +25,7 @@
         "body": {
             "default": "Klik op een van de opties om verder te gaan.",
             "switch": "Kies of je het signaal van een gekoppelde afstandsbediening wil kopiëren of dat je het apparaat wil programmeren met een nieuw signaal van Homey.",
-            "codewheel": "Kies of je het signaal van een gekoppelde afstandsbediening wil kopiëren of dat je de lettercodeshijf handmatig wil instellen.",
+            "codewheel": "Kies of je het signaal van een gekoppelde afstandsbediening wil kopiëren of dat je de lettercodeschijf handmatig wil instellen.",
             "dipswitch": "Kies of je het signaal van een gekoppelde afstandsbediening wil kopiëren of dat je de dipswitches handmatig wil instellen."
         },
         "buttons": {
@@ -34,7 +34,7 @@
             },
             "generate": {
                 "default": "Genereer nieuw signaal",
-                "codewheel": "lettercodeshijf instellen",
+                "codewheel": "lettercodeschijf instellen",
                 "dipswitch": "dipswitches instellen"
             }
         }
@@ -71,11 +71,11 @@
             "socket": "Test de contactdoos"
         },
         "body": {
-            "default": "Druk op een willekeurige knop op het apparaat of op de knoppen in het bovenstaande plaatje om het signaal te testen. Klik op volgende om verder te gaan.",
-            "remote": "Druk op een willekeurige knop op de afstandsbediening of op de knoppen in het bovenstaande plaatje om het signaal te testen. Klik op volgende om verder te gaan.",
-            "wall_switch": "Druk op een willekeurige knop op de wandschakelaar of op de knoppen in het bovenstaande plaatje om het signaal te testen. Klik op volgende om verder te gaan",
-            "socket_generated": "Gebruik te bovenstaande switch om de schakeldoos te testen. Klik op volgende om verder te gaan.",
-            "socket": "Gebruik de afstandsbediening of de bovenstaande switch om de schakeldoos te testen. Klik op volgende om verder te gaan.",
+            "default": "Druk op een willekeurige knop op het apparaat om het signaal te testen. Klik op volgende om verder te gaan.",
+            "remote": "Druk op een willekeurige knop op de afstandsbediening om het signaal te testen. Klik op volgende om verder te gaan.",
+            "wall_switch": "Druk op een willekeurige knop op de wandschakelaar om het signaal te testen. Klik op volgende om verder te gaan",
+            "socket_generated": "Gebruik de bovenstaande schakelaar om de schakeldoos te testen. Klik op volgende om verder te gaan.",
+            "socket": "Gebruik de afstandsbediening of de bovenstaande schakelaar om de schakeldoos te testen. Klik op volgende om verder te gaan.",
             "button_generated": "Gebruik de bovenstaande knop om het apparaat te testen. Klik op volgende om verder te gaan.",
             "button": "Gebruik de afstandsbediening of te bovenstaande knop om het apparaat te testen. Klik op volgende om verder te gaan.",
             "switch_generated": "Gebruik de bovenstaande knop om het apparaat te testen. Klik op volgende om verder te gaan.",
@@ -93,7 +93,7 @@
             "default": "Configureer de apparaatcode"
         },
         "body": {
-            "default": "Klik op de karakters op de bovenstaande lettercodeshijf of pas de lettercodeshijf op het apparaat aan zodat deze gelijk aan elkaar zijn, klik daarna op volgende."
+            "default": "Klik op de karakters op de bovenstaande lettercodeschijf of pas de lettercodeschijf op het apparaat aan zodat deze gelijk aan elkaar zijn, klik daarna op volgende."
         }
     },
     "dipswitch": {

--- a/.compose/templates/remote.json
+++ b/.compose/templates/remote.json
@@ -8,16 +8,12 @@
             "options": {
                 "title": "rf.pair.imitate.title.remote",
                 "body": "rf.pair.imitate.body.remote"
-            },
-            "navigation": {
-                "next": "rf.test"
             }
         },
         {
             "$template": "rf.test",
             "id": "rf.test",
             "navigation": {
-                "prev": "rf.imitate",
                 "next": "rf.done"
             }
         },

--- a/lib/Device.js
+++ b/lib/Device.js
@@ -655,11 +655,20 @@ module.exports = superclass =>
 			}
 			const frame = payload.map(Number);
 			const dataCheck = this.constructor.payloadToData(frame);
-			if (
-				frame.find(isNaN) || !dataCheck ||
-				dataCheck.constructor !== Object || !dataCheck.id ||
-				dataCheck.id !== this.getData().id
-			) {
+			
+			const hasInvalidType = !!frame.find(value => isNaN(value));
+			const hasNoData = !dataCheck;
+			const hasNoID = !dataCheck.id;
+			const hasNotSameID = dataCheck.id !== this.getData().id;
+
+			console.log('RF-driver send check, all should be false:', {
+				hasInvalidType,
+				hasNoData,
+				hasNoID,
+				hasNotSameID,
+			});
+			
+			if ( hasInvalidType || hasNoData || hasNoID || hasNotSameID ) {
 				const err = new Error(`Incorrect frame from dataToPayload(${JSON.stringify(data)}) => ${frame} => ${
 					JSON.stringify(dataCheck)}`);
 				this.logger.error(err);


### PR DESCRIPTION
Removed possibility to push remote buttons in the paring wizard. Changed locales accordingly.
Removed the navigation for pairing a remote if no signal was received.
Added additional logging to device.send function to see what part of a signal is invalid.