### PR TITLE
Bug: RF devices added twice when pairing

### DIFF
--- a/lib/RFDriver.js
+++ b/lib/RFDriver.js
@@ -169,6 +169,7 @@ class RFDriver extends Homey.Driver {
       if (!activeView) return;
       if (!isFirst) return;
       if (done) return;
+      done = true;
 
       await session.emit('createDevice', {
         name: this[sRF].name,
@@ -178,8 +179,6 @@ class RFDriver extends Homey.Driver {
           copiedFromRemote: true,
         },
       });
-
-      done = true;
     };
 
     await signal.registerRXListener(listener);


### PR DESCRIPTION
The 'done' check is done quite a while before the 'done' variable is updated. This made it possible for several listeners to pass the check before the value was to true.

Tested with the Alecto-ADB17 on the Homey pro 2023 an the Homey pro 2019 (3d).